### PR TITLE
Flexible upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,18 @@ openapi-validator-proxy proxy petstore.yaml http://localhost:8080
 
 This will read the OpenAPI file `petstore.yaml` and proxy requests to `http://localhost:8080`.
 
+Including a suffix on the upstream URL is also valid if you don't mount your routes directly at the root of the server. For example, if your server is mounted at `/api/v1` you can run:
+```
+openapi-validator-proxy proxy petstore.yaml http://localhost:8080/api/v1
+```
+
+Then make a GET request to the pets collection like this:
+```
+curl http://localhost:3000/api/v1/pets
+```
+This will proxy the request to `http://localhost:8080/api/v1/pets` and validate the request and response against the OpenAPI operation that matches `GET /pets`.
+
+
 ## Contributing
 
 ### Testing

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,8 @@ enum Commands {
         #[arg(value_name = "UPSTREAM")]
         upstream: url::Url,
 
-        #[arg(short, long)]
+        /// Port to run the proxy server on
+        #[arg(short, long, default_value = "3000")]
         port: Option<u16>,
     },
 }


### PR DESCRIPTION
## Problem

It'd be nice to specify a suffix to the upstream path such that you could still match routes in the OpenAPI spec, but make the proper request to your upstream server. An example would be helpful here. Previously, you'd be expected to invoke the tool like this:
```
openapi-validator-proxy proxy petstore.yaml http://localhost:8080
```
Then one of the paths in your spec would go to `/pets`. This would mean that you are forced to serve that path on `http://localhost:8080/pets`. It would be more flexible if you could include a suffix on the upstream url if you mounted your routes slightly differently, such as `http://localhost:8080/api/v1`.

## Solution

That's exactly what this PR does. Now you can invoke this tool with a suffix on upstream:
```
openapi-validator-proxy proxy petstore.yaml http://localhost:8080/api/v1
```
Then when you make a request to `http://localhost:3000/api/v1/pets` you will match the valid pets route for validation and also successfully route the request to your upstream server 🎉 