### PR TITLE
debug missing entries for Validation Failures

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@nightly
       - uses: swatinem/rust-cache@v2
 
       # If you use any mdbook plugins, here's the place to install them!
@@ -51,15 +51,8 @@ jobs:
       - name: Install and run oranda
         run: |
           curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/oranda/releases/download/v0.6.5/oranda-installer.sh | sh
-          cargo install mdbook
           cargo install mdbook-cmdrun
-          pwd
-          ls -al
-          ls -al docs
           oranda build
-          ls target
-          ls target/doc
-          cat public/book/validation_failures.html
       
       - name: Prepare HTML for link checking
         # untitaker/hyperlink supports no site prefixes, move entire site into

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -50,9 +50,12 @@ jobs:
       # This will write all output to ./public/ (including copying mdbook's output to there).
       - name: Install and run oranda
         run: |
-          curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/oranda/releases/download/v0.6.1/oranda-installer.sh | sh
+          curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/oranda/releases/download/v0.6.5/oranda-installer.sh | sh
           cargo install mdbook
           cargo install mdbook-cmdrun
+          pwd
+          ls -al
+          ls -al docs
           oranda build
           ls target
           ls target/doc

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -51,8 +51,12 @@ jobs:
       - name: Install and run oranda
         run: |
           curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/oranda/releases/download/v0.6.1/oranda-installer.sh | sh
+          cargo install mdbook
           cargo install mdbook-cmdrun
           oranda build
+          ls target
+          ls target/doc
+          cat public/book/validation_failures.html
       
       - name: Prepare HTML for link checking
         # untitaker/hyperlink supports no site prefixes, move entire site into


### PR DESCRIPTION
## Problem
The validation failures page was missing its entries.

## Solution
The reason this didn't work was because the script requires nightly functionality in rustdoc. Swapping to use nightly allows the entries to be created.