### PR TITLE
Don't try to parse a body for 204 and 304

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -433,9 +433,17 @@ fn validate_response(
         let value = HeaderValue::from_str(value).unwrap_or(HeaderValue::from_static(""));
         headers.insert(key, value);
     }
-    let body = response.into_string().unwrap();
+    let body_bytes = match status {
+        204 | 304 => vec![],
+        _ => {
+            let mut buffer: Vec<u8> = vec![];
+            response.into_reader().read_to_end(&mut buffer).unwrap();
+            buffer
+        }
+    };
+
     let mut validated = ValidatedResponse {
-        body: body.into_bytes(),
+        body: body_bytes,
         failures,
         headers: headers.clone(),
         method: method.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -437,7 +437,9 @@ fn validate_response(
         204 | 304 => vec![],
         _ => {
             let mut buffer: Vec<u8> = vec![];
-            response.into_reader().read_to_end(&mut buffer).unwrap();
+            // Failing to read the response body probably means a body wasn't included in the response.
+            // If that's the case, just return the empty buffer.
+            response.into_reader().read_to_end(&mut buffer).unwrap_or(0);
             buffer
         }
     };

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -399,3 +399,28 @@ fn failed_validation_unsupported_schema_kind() -> Result<(), Box<dyn std::error:
     insta::assert_snapshot!(xml);
     Ok(())
 }
+
+#[test]
+fn delete_with_204() -> Result<(), Box<dyn std::error::Error>> {
+    let mock_server = MockServer::start();
+    let mock = mock_server.mock(|when, then| {
+        // Prepare mock response with extra field
+        when.method(httpmock::Method::DELETE).path("/pets/1");
+        then.status(204);
+    });
+    let mut rng = rand::thread_rng();
+    let port: u16 = rng.gen_range(8000..u16::MAX);
+    let _proxy_handle = ValidatorProxyServerHandle::new(&mock_server.url(""), port);
+
+    ureq::delete(format!("http://localhost:{}/pets/1", port).as_str())
+        .set("OVP-Correlation-Id", "delete_with_204")
+        .call()
+        .or_any_status()
+        .expect("Failed to make request");
+    let junit = ureq::get(format!("http://localhost:{}/_ovp/junit", port).as_str()).call()?;
+    let xml = junit.into_string()?;
+    mock.assert();
+
+    insta::assert_snapshot!(xml);
+    Ok(())
+}

--- a/tests/petstore.yaml
+++ b/tests/petstore.yaml
@@ -88,6 +88,27 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+    delete:
+      summary: Deletes a pet
+      operationId: deletePet
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to delete
+          schema:
+            type: string
+      responses:
+        '204':
+          description: No Content
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   /missing_pets_schema:
     get:
       summary: An endpoint that references an invalid schema

--- a/tests/snapshots/integration__delete_with_204.snap
+++ b/tests/snapshots/integration__delete_with_204.snap
@@ -1,0 +1,16 @@
+---
+source: tests/integration.rs
+expression: xml
+---
+<testsuites tests="1" failures="0">
+    <testcase name="delete_with_204" time="0.00">
+        <properties>
+            <property name="path" value="/pets/1"></property>
+            <property name="method" value="DELETE"></property>
+            <property name="pathParameter-petId" value="1"></property>
+            <property name="statusCode" value="204"></property>
+            <property name="operationId" value="deletePet"></property>
+            <property name="responseContentType" value=""></property>
+        </properties>
+    </testcase>
+</testsuites>

--- a/tests/snapshots/integration__empty_body_200.snap
+++ b/tests/snapshots/integration__empty_body_200.snap
@@ -1,0 +1,16 @@
+---
+source: tests/integration.rs
+expression: xml
+---
+<testsuites tests="1" failures="1">
+    <testcase name="empty_body_200" time="0.00">
+        <properties>
+            <property name="path" value="/pets/1"></property>
+            <property name="method" value="DELETE"></property>
+            <property name="pathParameter-petId" value="1"></property>
+            <property name="statusCode" value="200"></property>
+            <property name="operationId" value="deletePet"></property>
+        </properties>
+        <failure type="InvalidStatusCode" message="error">Response not found for status code</failure>
+    </testcase>
+</testsuites>


### PR DESCRIPTION
## Problem
We always assume there's a response body and try to parse it out. This will panic in cases where there isn't actually a response body like with HTTP 204's

## Solution
Rely on status code if possible. If reading the body fails for other status codes, just give up on parsing the body 🤷 