### PR TITLE
Generic properties

### DIFF
--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -33,13 +33,13 @@ Which should return a JUnit report that resembles the following:
 ```xml
 <testsuites tests="1" failures="0">
     <testcase name="e73ac0a9-a28e-446c-aa21-aaad827a489d" time="0.26">
-        <properties>
-            <property name="path" value="/pets"></property>
-            <property name="method" value="GET"></property>
-            <property name="statusCode" value="200"></property>
-            <property name="operationId" value="getPets"></property>
-            <property name="responseContentType" value="application/json"></property>
-        </properties>
+        <system-out>
+[[PROPERTY|path=/pets]]
+[[PROPERTY|method=GET]]
+[[PROPERTY|statusCode=200]]
+[[PROPERTY|operationId=getPets]]
+[[PROPERTY|responseContentType=application/json]]
+        </system-out>
     </testcase>
 </testsuites>
 ```

--- a/templates/junit.xml
+++ b/templates/junit.xml
@@ -1,9 +1,9 @@
 <testsuites>
     <testsuite name="testsuite" tests="{{testcases.len()}}" failures="{{failed_testcases}}">{% for case in testcases %}
         <testcase name="{{case.name}}" time="{{case.time}}">
-            <properties>{% for prop in case.properties %}
-                <property name="{{prop.name}}" value="{{prop.value}}"></property>{% endfor %}
-            </properties>{% for failure in case.failures %}
+            <system-out>{% for prop in case.properties %}
+[[PROPERTY|{{prop.name}}={{prop.value}}]]{% endfor %}
+            </system-out>{% for failure in case.failures %}
             <failure type="{{failure.type}}" message="error">{{ failure.text|safe }}</failure>{% endfor %}
         </testcase>{% endfor %}
     </testsuite>

--- a/tests/snapshots/integration__delete_with_204.snap
+++ b/tests/snapshots/integration__delete_with_204.snap
@@ -5,14 +5,14 @@ expression: xml
 <testsuites>
     <testsuite name="testsuite" tests="1" failures="0">
         <testcase name="delete_with_204" time="0.00">
-            <properties>
-                <property name="path" value="/pets/1"></property>
-                <property name="method" value="DELETE"></property>
-                <property name="pathParameter-petId" value="1"></property>
-                <property name="statusCode" value="204"></property>
-                <property name="operationId" value="deletePet"></property>
-                <property name="responseContentType" value=""></property>
-            </properties>
+            <system-out>
+[[PROPERTY|path=/pets/1]]
+[[PROPERTY|method=DELETE]]
+[[PROPERTY|pathParameter-petId=1]]
+[[PROPERTY|statusCode=204]]
+[[PROPERTY|operationId=deletePet]]
+[[PROPERTY|responseContentType=]]
+            </system-out>
         </testcase>
     </testsuite>
 </testsuites>

--- a/tests/snapshots/integration__empty_body_200.snap
+++ b/tests/snapshots/integration__empty_body_200.snap
@@ -5,13 +5,13 @@ expression: xml
 <testsuites>
     <testsuite name="testsuite" tests="1" failures="1">
         <testcase name="empty_body_200" time="0.00">
-            <properties>
-                <property name="path" value="/pets/1"></property>
-                <property name="method" value="DELETE"></property>
-                <property name="pathParameter-petId" value="1"></property>
-                <property name="statusCode" value="200"></property>
-                <property name="operationId" value="deletePet"></property>
-            </properties>
+            <system-out>
+[[PROPERTY|path=/pets/1]]
+[[PROPERTY|method=DELETE]]
+[[PROPERTY|pathParameter-petId=1]]
+[[PROPERTY|statusCode=200]]
+[[PROPERTY|operationId=deletePet]]
+            </system-out>
             <failure type="InvalidStatusCode" message="error">Response not found for status code</failure>
         </testcase>
     </testsuite>

--- a/tests/snapshots/integration__failed_json_deserialization.snap
+++ b/tests/snapshots/integration__failed_json_deserialization.snap
@@ -5,14 +5,14 @@ expression: xml
 <testsuites>
     <testsuite name="testsuite" tests="1" failures="1">
         <testcase name="failed_json_deserialization" time="0.00">
-            <properties>
-                <property name="path" value="/pets/1"></property>
-                <property name="method" value="GET"></property>
-                <property name="pathParameter-petId" value="1"></property>
-                <property name="statusCode" value="200"></property>
-                <property name="operationId" value="showPetById"></property>
-                <property name="responseContentType" value="application/json"></property>
-            </properties>
+            <system-out>
+[[PROPERTY|path=/pets/1]]
+[[PROPERTY|method=GET]]
+[[PROPERTY|pathParameter-petId=1]]
+[[PROPERTY|statusCode=200]]
+[[PROPERTY|operationId=showPetById]]
+[[PROPERTY|responseContentType=application/json]]
+            </system-out>
             <failure type="FailedJSONDeserialization" message="error">Failed to parse response body as JSON</failure>
         </testcase>
     </testsuite>

--- a/tests/snapshots/integration__failed_validation_unexpected_boolean.snap
+++ b/tests/snapshots/integration__failed_validation_unexpected_boolean.snap
@@ -5,14 +5,14 @@ expression: xml
 <testsuites>
     <testsuite name="testsuite" tests="1" failures="1">
         <testcase name="failed_validation_unexpected_boolean" time="0.00">
-            <properties>
-                <property name="path" value="/pets/1"></property>
-                <property name="method" value="GET"></property>
-                <property name="pathParameter-petId" value="1"></property>
-                <property name="statusCode" value="200"></property>
-                <property name="operationId" value="showPetById"></property>
-                <property name="responseContentType" value="application/json"></property>
-            </properties>
+            <system-out>
+[[PROPERTY|path=/pets/1]]
+[[PROPERTY|method=GET]]
+[[PROPERTY|pathParameter-petId=1]]
+[[PROPERTY|statusCode=200]]
+[[PROPERTY|operationId=showPetById]]
+[[PROPERTY|responseContentType=application/json]]
+            </system-out>
             <failure type="FailedValidation.UnexpectedBoolean" message="error">Received unexpected boolean at /id/</failure>
         </testcase>
     </testsuite>

--- a/tests/snapshots/integration__failed_validation_unexpected_null.snap
+++ b/tests/snapshots/integration__failed_validation_unexpected_null.snap
@@ -5,14 +5,14 @@ expression: xml
 <testsuites>
     <testsuite name="testsuite" tests="1" failures="1">
         <testcase name="failed_validation_unexpected_null" time="0.00">
-            <properties>
-                <property name="path" value="/pets/1"></property>
-                <property name="method" value="GET"></property>
-                <property name="pathParameter-petId" value="1"></property>
-                <property name="statusCode" value="200"></property>
-                <property name="operationId" value="showPetById"></property>
-                <property name="responseContentType" value="application/json"></property>
-            </properties>
+            <system-out>
+[[PROPERTY|path=/pets/1]]
+[[PROPERTY|method=GET]]
+[[PROPERTY|pathParameter-petId=1]]
+[[PROPERTY|statusCode=200]]
+[[PROPERTY|operationId=showPetById]]
+[[PROPERTY|responseContentType=application/json]]
+            </system-out>
             <failure type="FailedValidation.UnexpectedNull" message="error">Received null value when null is not allowed at /id/</failure>
         </testcase>
     </testsuite>

--- a/tests/snapshots/integration__failed_validation_unexpected_number.snap
+++ b/tests/snapshots/integration__failed_validation_unexpected_number.snap
@@ -5,14 +5,14 @@ expression: xml
 <testsuites>
     <testsuite name="testsuite" tests="1" failures="1">
         <testcase name="failed_validation_unexpected_number" time="0.00">
-            <properties>
-                <property name="path" value="/pets/1"></property>
-                <property name="method" value="GET"></property>
-                <property name="pathParameter-petId" value="1"></property>
-                <property name="statusCode" value="200"></property>
-                <property name="operationId" value="showPetById"></property>
-                <property name="responseContentType" value="application/json"></property>
-            </properties>
+            <system-out>
+[[PROPERTY|path=/pets/1]]
+[[PROPERTY|method=GET]]
+[[PROPERTY|pathParameter-petId=1]]
+[[PROPERTY|statusCode=200]]
+[[PROPERTY|operationId=showPetById]]
+[[PROPERTY|responseContentType=application/json]]
+            </system-out>
             <failure type="FailedValidation.UnexpectedNumber" message="error">Received unexpected number at /name/</failure>
         </testcase>
     </testsuite>

--- a/tests/snapshots/integration__failed_validation_unexpected_property.snap
+++ b/tests/snapshots/integration__failed_validation_unexpected_property.snap
@@ -5,14 +5,14 @@ expression: xml
 <testsuites>
     <testsuite name="testsuite" tests="1" failures="1">
         <testcase name="failed_validation_unexpected_property" time="0.00">
-            <properties>
-                <property name="path" value="/pets/1"></property>
-                <property name="method" value="GET"></property>
-                <property name="pathParameter-petId" value="1"></property>
-                <property name="statusCode" value="200"></property>
-                <property name="operationId" value="showPetById"></property>
-                <property name="responseContentType" value="application/json"></property>
-            </properties>
+            <system-out>
+[[PROPERTY|path=/pets/1]]
+[[PROPERTY|method=GET]]
+[[PROPERTY|pathParameter-petId=1]]
+[[PROPERTY|statusCode=200]]
+[[PROPERTY|operationId=showPetById]]
+[[PROPERTY|responseContentType=application/json]]
+            </system-out>
             <failure type="FailedValidation.UnexpectedProperty" message="error">Unexpected property at /extra, value "field"</failure>
         </testcase>
     </testsuite>

--- a/tests/snapshots/integration__failed_validation_unexpected_string.snap
+++ b/tests/snapshots/integration__failed_validation_unexpected_string.snap
@@ -5,14 +5,14 @@ expression: xml
 <testsuites>
     <testsuite name="testsuite" tests="1" failures="1">
         <testcase name="failed_validation_unexpected_string" time="0.00">
-            <properties>
-                <property name="path" value="/pets/1"></property>
-                <property name="method" value="GET"></property>
-                <property name="pathParameter-petId" value="1"></property>
-                <property name="statusCode" value="200"></property>
-                <property name="operationId" value="showPetById"></property>
-                <property name="responseContentType" value="application/json"></property>
-            </properties>
+            <system-out>
+[[PROPERTY|path=/pets/1]]
+[[PROPERTY|method=GET]]
+[[PROPERTY|pathParameter-petId=1]]
+[[PROPERTY|statusCode=200]]
+[[PROPERTY|operationId=showPetById]]
+[[PROPERTY|responseContentType=application/json]]
+            </system-out>
             <failure type="FailedValidation.UnexpectedString" message="error">Received unexpected string at /id/</failure>
         </testcase>
     </testsuite>

--- a/tests/snapshots/integration__failed_validation_unsupported_schema_kind.snap
+++ b/tests/snapshots/integration__failed_validation_unsupported_schema_kind.snap
@@ -5,13 +5,13 @@ expression: xml
 <testsuites>
     <testsuite name="testsuite" tests="1" failures="1">
         <testcase name="failed_validation_unsupported_schema_kind" time="0.00">
-            <properties>
-                <property name="path" value="/any_of_pet_schema"></property>
-                <property name="method" value="GET"></property>
-                <property name="statusCode" value="200"></property>
-                <property name="operationId" value="anyOfPetSchema"></property>
-                <property name="responseContentType" value="application/json"></property>
-            </properties>
+            <system-out>
+[[PROPERTY|path=/any_of_pet_schema]]
+[[PROPERTY|method=GET]]
+[[PROPERTY|statusCode=200]]
+[[PROPERTY|operationId=anyOfPetSchema]]
+[[PROPERTY|responseContentType=application/json]]
+            </system-out>
             <failure type="FailedValidation.UnsupportedSchemaKind" message="error">Received unsupported schema kind: AnyOf { any_of: [Reference { reference: "#/components/schemas/Pet" }, Item(Schema { schema_data: SchemaData { nullable: false, read_only: false, write_only: false, deprecated: false, external_docs: None, example: None, title: None, description: None, discriminator: None, default: None, extensions: {} }, schema_kind: Type(Object(ObjectType { properties: {"id": Item(Schema { schema_data: SchemaData { nullable: false, read_only: false, write_only: false, deprecated: false, external_docs: None, example: None, title: None, description: None, discriminator: None, default: None, extensions: {} }, schema_kind: Type(Integer(IntegerType { format: Item(Int64), multiple_of: None, exclusive_minimum: false, exclusive_maximum: false, minimum: None, maximum: None, enumeration: [] })) }), "name": Item(Schema { schema_data: SchemaData { nullable: false, read_only: false, write_only: false, deprecated: false, external_docs: None, example: None, title: None, description: None, discriminator: None, default: None, extensions: {} }, schema_kind: Type(String(StringType { format: Empty, pattern: None, enumeration: [], min_length: None, max_length: None })) })}, required: ["id", "name"], additional_properties: None, min_properties: None, max_properties: None })) })] } at /</failure>
         </testcase>
     </testsuite>

--- a/tests/snapshots/integration__invalid_http_method.snap
+++ b/tests/snapshots/integration__invalid_http_method.snap
@@ -5,11 +5,11 @@ expression: xml
 <testsuites>
     <testsuite name="testsuite" tests="1" failures="1">
         <testcase name="invalid_http_method" time="0.00">
-            <properties>
-                <property name="path" value="/pets"></property>
-                <property name="method" value="DELETE"></property>
-                <property name="statusCode" value="405"></property>
-            </properties>
+            <system-out>
+[[PROPERTY|path=/pets]]
+[[PROPERTY|method=DELETE]]
+[[PROPERTY|statusCode=405]]
+            </system-out>
             <failure type="InvalidHTTPMethod" message="error">Invalid HTTP method</failure>
         </testcase>
     </testsuite>

--- a/tests/snapshots/integration__invalid_status_code.snap
+++ b/tests/snapshots/integration__invalid_status_code.snap
@@ -5,12 +5,12 @@ expression: xml
 <testsuites>
     <testsuite name="testsuite" tests="1" failures="1">
         <testcase name="invalid_status_code" time="0.00">
-            <properties>
-                <property name="path" value="/pets"></property>
-                <property name="method" value="GET"></property>
-                <property name="statusCode" value="600"></property>
-                <property name="operationId" value="listPets"></property>
-            </properties>
+            <system-out>
+[[PROPERTY|path=/pets]]
+[[PROPERTY|method=GET]]
+[[PROPERTY|statusCode=600]]
+[[PROPERTY|operationId=listPets]]
+            </system-out>
             <failure type="InvalidStatusCode" message="error">Response not found for status code</failure>
         </testcase>
     </testsuite>

--- a/tests/snapshots/integration__mismatch_non_empty_body.snap
+++ b/tests/snapshots/integration__mismatch_non_empty_body.snap
@@ -5,14 +5,14 @@ expression: xml
 <testsuites>
     <testsuite name="testsuite" tests="1" failures="1">
         <testcase name="mismatch_non_empty_body" time="0.00">
-            <properties>
-                <property name="path" value="/pets/1"></property>
-                <property name="method" value="GET"></property>
-                <property name="pathParameter-petId" value="1"></property>
-                <property name="statusCode" value="202"></property>
-                <property name="operationId" value="showPetById"></property>
-                <property name="responseContentType" value=""></property>
-            </properties>
+            <system-out>
+[[PROPERTY|path=/pets/1]]
+[[PROPERTY|method=GET]]
+[[PROPERTY|pathParameter-petId=1]]
+[[PROPERTY|statusCode=202]]
+[[PROPERTY|operationId=showPetById]]
+[[PROPERTY|responseContentType=]]
+            </system-out>
             <failure type="MismatchNonEmptyBody" message="error">Receieved response body when empty body is expected</failure>
         </testcase>
     </testsuite>

--- a/tests/snapshots/integration__mismatched_content_type_header.snap
+++ b/tests/snapshots/integration__mismatched_content_type_header.snap
@@ -5,13 +5,13 @@ expression: xml
 <testsuites>
     <testsuite name="testsuite" tests="1" failures="1">
         <testcase name="mismatched_content_type_header" time="0.00">
-            <properties>
-                <property name="path" value="/pets"></property>
-                <property name="method" value="GET"></property>
-                <property name="statusCode" value="200"></property>
-                <property name="operationId" value="listPets"></property>
-                <property name="responseContentType" value="wrong"></property>
-            </properties>
+            <system-out>
+[[PROPERTY|path=/pets]]
+[[PROPERTY|method=GET]]
+[[PROPERTY|statusCode=200]]
+[[PROPERTY|operationId=listPets]]
+[[PROPERTY|responseContentType=wrong]]
+            </system-out>
             <failure type="MismatchedContentTypeHeader" message="error">Spec does not contain matching response for Content-Type: wrong</failure>
         </testcase>
     </testsuite>

--- a/tests/snapshots/integration__missing_content_type_header.snap
+++ b/tests/snapshots/integration__missing_content_type_header.snap
@@ -5,12 +5,12 @@ expression: xml
 <testsuites>
     <testsuite name="testsuite" tests="1" failures="1">
         <testcase name="missing_content_type_header" time="0.00">
-            <properties>
-                <property name="path" value="/pets"></property>
-                <property name="method" value="GET"></property>
-                <property name="statusCode" value="200"></property>
-                <property name="operationId" value="listPets"></property>
-            </properties>
+            <system-out>
+[[PROPERTY|path=/pets]]
+[[PROPERTY|method=GET]]
+[[PROPERTY|statusCode=200]]
+[[PROPERTY|operationId=listPets]]
+            </system-out>
             <failure type="MissingContentTypeHeader" message="error">Response did not include a Content-Type header</failure>
         </testcase>
     </testsuite>

--- a/tests/snapshots/integration__missing_schema_definition.snap
+++ b/tests/snapshots/integration__missing_schema_definition.snap
@@ -5,13 +5,13 @@ expression: xml
 <testsuites>
     <testsuite name="testsuite" tests="1" failures="1">
         <testcase name="missing_schema_definition" time="0.00">
-            <properties>
-                <property name="path" value="/missing_pets_schema"></property>
-                <property name="method" value="GET"></property>
-                <property name="statusCode" value="200"></property>
-                <property name="operationId" value="missingPetsSchema"></property>
-                <property name="responseContentType" value="application/json"></property>
-            </properties>
+            <system-out>
+[[PROPERTY|path=/missing_pets_schema]]
+[[PROPERTY|method=GET]]
+[[PROPERTY|statusCode=200]]
+[[PROPERTY|operationId=missingPetsSchema]]
+[[PROPERTY|responseContentType=application/json]]
+            </system-out>
             <failure type="MissingSchemaDefinition" message="error">Could not find schema defined inline or as a #/components/schemas/ reference</failure>
         </testcase>
     </testsuite>

--- a/tests/snapshots/integration__path_not_found.snap
+++ b/tests/snapshots/integration__path_not_found.snap
@@ -5,11 +5,11 @@ expression: xml
 <testsuites>
     <testsuite name="testsuite" tests="1" failures="1">
         <testcase name="path_not_found" time="0.00">
-            <properties>
-                <property name="path" value="/pet"></property>
-                <property name="method" value="GET"></property>
-                <property name="statusCode" value="404"></property>
-            </properties>
+            <system-out>
+[[PROPERTY|path=/pet]]
+[[PROPERTY|method=GET]]
+[[PROPERTY|statusCode=404]]
+            </system-out>
             <failure type="PathNotFound" message="error">Path not found</failure>
         </testcase>
     </testsuite>


### PR DESCRIPTION
## Problem

Support for the properties tag within a test case isn't great. 

## Solution
Using system-out instead is a solution with much wider support. Potentially this could be exposed with configuration in the future.