### PR TITLE
Testcase names

### DIFF
--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -34,11 +34,18 @@ Which should return a JUnit report that resembles the following:
 <testsuites tests="1" failures="0">
     <testcase name="e73ac0a9-a28e-446c-aa21-aaad827a489d" time="0.26">
         <system-out>
-[[PROPERTY|path=/pets]]
+[[PROPERTY|correlationId=e73ac0a9-a28e-446c-aa21-aaad827a489d]]
 [[PROPERTY|method=GET]]
-[[PROPERTY|statusCode=200]]
 [[PROPERTY|operationId=getPets]]
+[[PROPERTY|path=/pets]]
 [[PROPERTY|responseContentType=application/json]]
+[[PROPERTY|statusCode=200]]
+correlationId=e73ac0a9-a28e-446c-aa21-aaad827a489d
+method=GET
+operationId=getPets
+path=/pets
+responseContentType=application/json
+statusCode=200
         </system-out>
     </testcase>
 </testsuites>

--- a/templates/junit.xml
+++ b/templates/junit.xml
@@ -1,8 +1,9 @@
 <testsuites>
-    <testsuite name="testsuite" tests="{{testcases.len()}}" failures="{{failed_testcases}}">{% for case in testcases %}
+    <testsuite name="openapi-validator-proxy" tests="{{testcases.len()}}" failures="{{failed_testcases}}">{% for case in testcases %}
         <testcase name="{{case.name}}" time="{{case.time}}">
             <system-out>{% for prop in case.properties %}
-[[PROPERTY|{{prop.name}}={{prop.value}}]]{% endfor %}
+[[PROPERTY|{{prop.name}}={{prop.value}}]]{% endfor %}{% for prop in case.properties %}
+{{prop.name}}={{prop.value}}{% endfor %}
             </system-out>{% for failure in case.failures %}
             <failure type="{{failure.type}}" message="error">{{ failure.text|safe }}</failure>{% endfor %}
         </testcase>{% endfor %}

--- a/tests/snapshots/integration__delete_with_204.snap
+++ b/tests/snapshots/integration__delete_with_204.snap
@@ -3,15 +3,23 @@ source: tests/integration.rs
 expression: xml
 ---
 <testsuites>
-    <testsuite name="testsuite" tests="1" failures="0">
-        <testcase name="delete_with_204" time="0.00">
+    <testsuite name="openapi-validator-proxy" tests="1" failures="0">
+        <testcase name="DELETE /pets/1 delete_with_204" time="0.00">
             <system-out>
-[[PROPERTY|path=/pets/1]]
+[[PROPERTY|correlationId=delete_with_204]]
 [[PROPERTY|method=DELETE]]
-[[PROPERTY|pathParameter-petId=1]]
-[[PROPERTY|statusCode=204]]
 [[PROPERTY|operationId=deletePet]]
+[[PROPERTY|path=/pets/1]]
+[[PROPERTY|pathParameter-petId=1]]
 [[PROPERTY|responseContentType=]]
+[[PROPERTY|statusCode=204]]
+correlationId=delete_with_204
+method=DELETE
+operationId=deletePet
+path=/pets/1
+pathParameter-petId=1
+responseContentType=
+statusCode=204
             </system-out>
         </testcase>
     </testsuite>

--- a/tests/snapshots/integration__empty_body_200.snap
+++ b/tests/snapshots/integration__empty_body_200.snap
@@ -3,14 +3,21 @@ source: tests/integration.rs
 expression: xml
 ---
 <testsuites>
-    <testsuite name="testsuite" tests="1" failures="1">
-        <testcase name="empty_body_200" time="0.00">
+    <testsuite name="openapi-validator-proxy" tests="1" failures="1">
+        <testcase name="DELETE /pets/1 empty_body_200" time="0.00">
             <system-out>
-[[PROPERTY|path=/pets/1]]
+[[PROPERTY|correlationId=empty_body_200]]
 [[PROPERTY|method=DELETE]]
+[[PROPERTY|operationId=deletePet]]
+[[PROPERTY|path=/pets/1]]
 [[PROPERTY|pathParameter-petId=1]]
 [[PROPERTY|statusCode=200]]
-[[PROPERTY|operationId=deletePet]]
+correlationId=empty_body_200
+method=DELETE
+operationId=deletePet
+path=/pets/1
+pathParameter-petId=1
+statusCode=200
             </system-out>
             <failure type="InvalidStatusCode" message="error">Response not found for status code</failure>
         </testcase>

--- a/tests/snapshots/integration__failed_json_deserialization.snap
+++ b/tests/snapshots/integration__failed_json_deserialization.snap
@@ -3,15 +3,23 @@ source: tests/integration.rs
 expression: xml
 ---
 <testsuites>
-    <testsuite name="testsuite" tests="1" failures="1">
-        <testcase name="failed_json_deserialization" time="0.00">
+    <testsuite name="openapi-validator-proxy" tests="1" failures="1">
+        <testcase name="GET /pets/1 failed_json_deserialization" time="0.00">
             <system-out>
-[[PROPERTY|path=/pets/1]]
+[[PROPERTY|correlationId=failed_json_deserialization]]
 [[PROPERTY|method=GET]]
-[[PROPERTY|pathParameter-petId=1]]
-[[PROPERTY|statusCode=200]]
 [[PROPERTY|operationId=showPetById]]
+[[PROPERTY|path=/pets/1]]
+[[PROPERTY|pathParameter-petId=1]]
 [[PROPERTY|responseContentType=application/json]]
+[[PROPERTY|statusCode=200]]
+correlationId=failed_json_deserialization
+method=GET
+operationId=showPetById
+path=/pets/1
+pathParameter-petId=1
+responseContentType=application/json
+statusCode=200
             </system-out>
             <failure type="FailedJSONDeserialization" message="error">Failed to parse response body as JSON</failure>
         </testcase>

--- a/tests/snapshots/integration__failed_validation_unexpected_boolean.snap
+++ b/tests/snapshots/integration__failed_validation_unexpected_boolean.snap
@@ -3,15 +3,23 @@ source: tests/integration.rs
 expression: xml
 ---
 <testsuites>
-    <testsuite name="testsuite" tests="1" failures="1">
-        <testcase name="failed_validation_unexpected_boolean" time="0.00">
+    <testsuite name="openapi-validator-proxy" tests="1" failures="1">
+        <testcase name="GET /pets/1 failed_validation_unexpected_boolean" time="0.00">
             <system-out>
-[[PROPERTY|path=/pets/1]]
+[[PROPERTY|correlationId=failed_validation_unexpected_boolean]]
 [[PROPERTY|method=GET]]
-[[PROPERTY|pathParameter-petId=1]]
-[[PROPERTY|statusCode=200]]
 [[PROPERTY|operationId=showPetById]]
+[[PROPERTY|path=/pets/1]]
+[[PROPERTY|pathParameter-petId=1]]
 [[PROPERTY|responseContentType=application/json]]
+[[PROPERTY|statusCode=200]]
+correlationId=failed_validation_unexpected_boolean
+method=GET
+operationId=showPetById
+path=/pets/1
+pathParameter-petId=1
+responseContentType=application/json
+statusCode=200
             </system-out>
             <failure type="FailedValidation.UnexpectedBoolean" message="error">Received unexpected boolean at /id/</failure>
         </testcase>

--- a/tests/snapshots/integration__failed_validation_unexpected_null.snap
+++ b/tests/snapshots/integration__failed_validation_unexpected_null.snap
@@ -3,15 +3,23 @@ source: tests/integration.rs
 expression: xml
 ---
 <testsuites>
-    <testsuite name="testsuite" tests="1" failures="1">
-        <testcase name="failed_validation_unexpected_null" time="0.00">
+    <testsuite name="openapi-validator-proxy" tests="1" failures="1">
+        <testcase name="GET /pets/1 failed_validation_unexpected_null" time="0.00">
             <system-out>
-[[PROPERTY|path=/pets/1]]
+[[PROPERTY|correlationId=failed_validation_unexpected_null]]
 [[PROPERTY|method=GET]]
-[[PROPERTY|pathParameter-petId=1]]
-[[PROPERTY|statusCode=200]]
 [[PROPERTY|operationId=showPetById]]
+[[PROPERTY|path=/pets/1]]
+[[PROPERTY|pathParameter-petId=1]]
 [[PROPERTY|responseContentType=application/json]]
+[[PROPERTY|statusCode=200]]
+correlationId=failed_validation_unexpected_null
+method=GET
+operationId=showPetById
+path=/pets/1
+pathParameter-petId=1
+responseContentType=application/json
+statusCode=200
             </system-out>
             <failure type="FailedValidation.UnexpectedNull" message="error">Received null value when null is not allowed at /id/</failure>
         </testcase>

--- a/tests/snapshots/integration__failed_validation_unexpected_number.snap
+++ b/tests/snapshots/integration__failed_validation_unexpected_number.snap
@@ -3,15 +3,23 @@ source: tests/integration.rs
 expression: xml
 ---
 <testsuites>
-    <testsuite name="testsuite" tests="1" failures="1">
-        <testcase name="failed_validation_unexpected_number" time="0.00">
+    <testsuite name="openapi-validator-proxy" tests="1" failures="1">
+        <testcase name="GET /pets/1 failed_validation_unexpected_number" time="0.00">
             <system-out>
-[[PROPERTY|path=/pets/1]]
+[[PROPERTY|correlationId=failed_validation_unexpected_number]]
 [[PROPERTY|method=GET]]
-[[PROPERTY|pathParameter-petId=1]]
-[[PROPERTY|statusCode=200]]
 [[PROPERTY|operationId=showPetById]]
+[[PROPERTY|path=/pets/1]]
+[[PROPERTY|pathParameter-petId=1]]
 [[PROPERTY|responseContentType=application/json]]
+[[PROPERTY|statusCode=200]]
+correlationId=failed_validation_unexpected_number
+method=GET
+operationId=showPetById
+path=/pets/1
+pathParameter-petId=1
+responseContentType=application/json
+statusCode=200
             </system-out>
             <failure type="FailedValidation.UnexpectedNumber" message="error">Received unexpected number at /name/</failure>
         </testcase>

--- a/tests/snapshots/integration__failed_validation_unexpected_property.snap
+++ b/tests/snapshots/integration__failed_validation_unexpected_property.snap
@@ -3,15 +3,23 @@ source: tests/integration.rs
 expression: xml
 ---
 <testsuites>
-    <testsuite name="testsuite" tests="1" failures="1">
-        <testcase name="failed_validation_unexpected_property" time="0.00">
+    <testsuite name="openapi-validator-proxy" tests="1" failures="1">
+        <testcase name="GET /pets/1 failed_validation_unexpected_property" time="0.00">
             <system-out>
-[[PROPERTY|path=/pets/1]]
+[[PROPERTY|correlationId=failed_validation_unexpected_property]]
 [[PROPERTY|method=GET]]
-[[PROPERTY|pathParameter-petId=1]]
-[[PROPERTY|statusCode=200]]
 [[PROPERTY|operationId=showPetById]]
+[[PROPERTY|path=/pets/1]]
+[[PROPERTY|pathParameter-petId=1]]
 [[PROPERTY|responseContentType=application/json]]
+[[PROPERTY|statusCode=200]]
+correlationId=failed_validation_unexpected_property
+method=GET
+operationId=showPetById
+path=/pets/1
+pathParameter-petId=1
+responseContentType=application/json
+statusCode=200
             </system-out>
             <failure type="FailedValidation.UnexpectedProperty" message="error">Unexpected property at /extra, value "field"</failure>
         </testcase>

--- a/tests/snapshots/integration__failed_validation_unexpected_string.snap
+++ b/tests/snapshots/integration__failed_validation_unexpected_string.snap
@@ -3,15 +3,23 @@ source: tests/integration.rs
 expression: xml
 ---
 <testsuites>
-    <testsuite name="testsuite" tests="1" failures="1">
-        <testcase name="failed_validation_unexpected_string" time="0.00">
+    <testsuite name="openapi-validator-proxy" tests="1" failures="1">
+        <testcase name="GET /pets/1 failed_validation_unexpected_string" time="0.00">
             <system-out>
-[[PROPERTY|path=/pets/1]]
+[[PROPERTY|correlationId=failed_validation_unexpected_string]]
 [[PROPERTY|method=GET]]
-[[PROPERTY|pathParameter-petId=1]]
-[[PROPERTY|statusCode=200]]
 [[PROPERTY|operationId=showPetById]]
+[[PROPERTY|path=/pets/1]]
+[[PROPERTY|pathParameter-petId=1]]
 [[PROPERTY|responseContentType=application/json]]
+[[PROPERTY|statusCode=200]]
+correlationId=failed_validation_unexpected_string
+method=GET
+operationId=showPetById
+path=/pets/1
+pathParameter-petId=1
+responseContentType=application/json
+statusCode=200
             </system-out>
             <failure type="FailedValidation.UnexpectedString" message="error">Received unexpected string at /id/</failure>
         </testcase>

--- a/tests/snapshots/integration__failed_validation_unsupported_schema_kind.snap
+++ b/tests/snapshots/integration__failed_validation_unsupported_schema_kind.snap
@@ -3,14 +3,21 @@ source: tests/integration.rs
 expression: xml
 ---
 <testsuites>
-    <testsuite name="testsuite" tests="1" failures="1">
-        <testcase name="failed_validation_unsupported_schema_kind" time="0.00">
+    <testsuite name="openapi-validator-proxy" tests="1" failures="1">
+        <testcase name="GET /any_of_pet_schema failed_validation_unsupported_schema_kind" time="0.00">
             <system-out>
-[[PROPERTY|path=/any_of_pet_schema]]
+[[PROPERTY|correlationId=failed_validation_unsupported_schema_kind]]
 [[PROPERTY|method=GET]]
-[[PROPERTY|statusCode=200]]
 [[PROPERTY|operationId=anyOfPetSchema]]
+[[PROPERTY|path=/any_of_pet_schema]]
 [[PROPERTY|responseContentType=application/json]]
+[[PROPERTY|statusCode=200]]
+correlationId=failed_validation_unsupported_schema_kind
+method=GET
+operationId=anyOfPetSchema
+path=/any_of_pet_schema
+responseContentType=application/json
+statusCode=200
             </system-out>
             <failure type="FailedValidation.UnsupportedSchemaKind" message="error">Received unsupported schema kind: AnyOf { any_of: [Reference { reference: "#/components/schemas/Pet" }, Item(Schema { schema_data: SchemaData { nullable: false, read_only: false, write_only: false, deprecated: false, external_docs: None, example: None, title: None, description: None, discriminator: None, default: None, extensions: {} }, schema_kind: Type(Object(ObjectType { properties: {"id": Item(Schema { schema_data: SchemaData { nullable: false, read_only: false, write_only: false, deprecated: false, external_docs: None, example: None, title: None, description: None, discriminator: None, default: None, extensions: {} }, schema_kind: Type(Integer(IntegerType { format: Item(Int64), multiple_of: None, exclusive_minimum: false, exclusive_maximum: false, minimum: None, maximum: None, enumeration: [] })) }), "name": Item(Schema { schema_data: SchemaData { nullable: false, read_only: false, write_only: false, deprecated: false, external_docs: None, example: None, title: None, description: None, discriminator: None, default: None, extensions: {} }, schema_kind: Type(String(StringType { format: Empty, pattern: None, enumeration: [], min_length: None, max_length: None })) })}, required: ["id", "name"], additional_properties: None, min_properties: None, max_properties: None })) })] } at /</failure>
         </testcase>

--- a/tests/snapshots/integration__invalid_http_method.snap
+++ b/tests/snapshots/integration__invalid_http_method.snap
@@ -3,12 +3,17 @@ source: tests/integration.rs
 expression: xml
 ---
 <testsuites>
-    <testsuite name="testsuite" tests="1" failures="1">
-        <testcase name="invalid_http_method" time="0.00">
+    <testsuite name="openapi-validator-proxy" tests="1" failures="1">
+        <testcase name="DELETE /pets invalid_http_method" time="0.00">
             <system-out>
-[[PROPERTY|path=/pets]]
+[[PROPERTY|correlationId=invalid_http_method]]
 [[PROPERTY|method=DELETE]]
+[[PROPERTY|path=/pets]]
 [[PROPERTY|statusCode=405]]
+correlationId=invalid_http_method
+method=DELETE
+path=/pets
+statusCode=405
             </system-out>
             <failure type="InvalidHTTPMethod" message="error">Invalid HTTP method</failure>
         </testcase>

--- a/tests/snapshots/integration__invalid_status_code.snap
+++ b/tests/snapshots/integration__invalid_status_code.snap
@@ -3,13 +3,19 @@ source: tests/integration.rs
 expression: xml
 ---
 <testsuites>
-    <testsuite name="testsuite" tests="1" failures="1">
-        <testcase name="invalid_status_code" time="0.00">
+    <testsuite name="openapi-validator-proxy" tests="1" failures="1">
+        <testcase name="GET /pets invalid_status_code" time="0.00">
             <system-out>
-[[PROPERTY|path=/pets]]
+[[PROPERTY|correlationId=invalid_status_code]]
 [[PROPERTY|method=GET]]
-[[PROPERTY|statusCode=600]]
 [[PROPERTY|operationId=listPets]]
+[[PROPERTY|path=/pets]]
+[[PROPERTY|statusCode=600]]
+correlationId=invalid_status_code
+method=GET
+operationId=listPets
+path=/pets
+statusCode=600
             </system-out>
             <failure type="InvalidStatusCode" message="error">Response not found for status code</failure>
         </testcase>

--- a/tests/snapshots/integration__mismatch_non_empty_body.snap
+++ b/tests/snapshots/integration__mismatch_non_empty_body.snap
@@ -3,15 +3,23 @@ source: tests/integration.rs
 expression: xml
 ---
 <testsuites>
-    <testsuite name="testsuite" tests="1" failures="1">
-        <testcase name="mismatch_non_empty_body" time="0.00">
+    <testsuite name="openapi-validator-proxy" tests="1" failures="1">
+        <testcase name="GET /pets/1 mismatch_non_empty_body" time="0.00">
             <system-out>
-[[PROPERTY|path=/pets/1]]
+[[PROPERTY|correlationId=mismatch_non_empty_body]]
 [[PROPERTY|method=GET]]
-[[PROPERTY|pathParameter-petId=1]]
-[[PROPERTY|statusCode=202]]
 [[PROPERTY|operationId=showPetById]]
+[[PROPERTY|path=/pets/1]]
+[[PROPERTY|pathParameter-petId=1]]
 [[PROPERTY|responseContentType=]]
+[[PROPERTY|statusCode=202]]
+correlationId=mismatch_non_empty_body
+method=GET
+operationId=showPetById
+path=/pets/1
+pathParameter-petId=1
+responseContentType=
+statusCode=202
             </system-out>
             <failure type="MismatchNonEmptyBody" message="error">Receieved response body when empty body is expected</failure>
         </testcase>

--- a/tests/snapshots/integration__mismatched_content_type_header.snap
+++ b/tests/snapshots/integration__mismatched_content_type_header.snap
@@ -3,14 +3,21 @@ source: tests/integration.rs
 expression: xml
 ---
 <testsuites>
-    <testsuite name="testsuite" tests="1" failures="1">
-        <testcase name="mismatched_content_type_header" time="0.00">
+    <testsuite name="openapi-validator-proxy" tests="1" failures="1">
+        <testcase name="GET /pets mismatched_content_type_header" time="0.00">
             <system-out>
-[[PROPERTY|path=/pets]]
+[[PROPERTY|correlationId=mismatched_content_type_header]]
 [[PROPERTY|method=GET]]
-[[PROPERTY|statusCode=200]]
 [[PROPERTY|operationId=listPets]]
+[[PROPERTY|path=/pets]]
 [[PROPERTY|responseContentType=wrong]]
+[[PROPERTY|statusCode=200]]
+correlationId=mismatched_content_type_header
+method=GET
+operationId=listPets
+path=/pets
+responseContentType=wrong
+statusCode=200
             </system-out>
             <failure type="MismatchedContentTypeHeader" message="error">Spec does not contain matching response for Content-Type: wrong</failure>
         </testcase>

--- a/tests/snapshots/integration__missing_content_type_header.snap
+++ b/tests/snapshots/integration__missing_content_type_header.snap
@@ -3,13 +3,19 @@ source: tests/integration.rs
 expression: xml
 ---
 <testsuites>
-    <testsuite name="testsuite" tests="1" failures="1">
-        <testcase name="missing_content_type_header" time="0.00">
+    <testsuite name="openapi-validator-proxy" tests="1" failures="1">
+        <testcase name="GET /pets missing_content_type_header" time="0.00">
             <system-out>
-[[PROPERTY|path=/pets]]
+[[PROPERTY|correlationId=missing_content_type_header]]
 [[PROPERTY|method=GET]]
-[[PROPERTY|statusCode=200]]
 [[PROPERTY|operationId=listPets]]
+[[PROPERTY|path=/pets]]
+[[PROPERTY|statusCode=200]]
+correlationId=missing_content_type_header
+method=GET
+operationId=listPets
+path=/pets
+statusCode=200
             </system-out>
             <failure type="MissingContentTypeHeader" message="error">Response did not include a Content-Type header</failure>
         </testcase>

--- a/tests/snapshots/integration__missing_schema_definition.snap
+++ b/tests/snapshots/integration__missing_schema_definition.snap
@@ -3,14 +3,21 @@ source: tests/integration.rs
 expression: xml
 ---
 <testsuites>
-    <testsuite name="testsuite" tests="1" failures="1">
-        <testcase name="missing_schema_definition" time="0.00">
+    <testsuite name="openapi-validator-proxy" tests="1" failures="1">
+        <testcase name="GET /missing_pets_schema missing_schema_definition" time="0.00">
             <system-out>
-[[PROPERTY|path=/missing_pets_schema]]
+[[PROPERTY|correlationId=missing_schema_definition]]
 [[PROPERTY|method=GET]]
-[[PROPERTY|statusCode=200]]
 [[PROPERTY|operationId=missingPetsSchema]]
+[[PROPERTY|path=/missing_pets_schema]]
 [[PROPERTY|responseContentType=application/json]]
+[[PROPERTY|statusCode=200]]
+correlationId=missing_schema_definition
+method=GET
+operationId=missingPetsSchema
+path=/missing_pets_schema
+responseContentType=application/json
+statusCode=200
             </system-out>
             <failure type="MissingSchemaDefinition" message="error">Could not find schema defined inline or as a #/components/schemas/ reference</failure>
         </testcase>

--- a/tests/snapshots/integration__path_not_found.snap
+++ b/tests/snapshots/integration__path_not_found.snap
@@ -3,12 +3,17 @@ source: tests/integration.rs
 expression: xml
 ---
 <testsuites>
-    <testsuite name="testsuite" tests="1" failures="1">
-        <testcase name="path_not_found" time="0.00">
+    <testsuite name="openapi-validator-proxy" tests="1" failures="1">
+        <testcase name="GET /pet path_not_found" time="0.00">
             <system-out>
-[[PROPERTY|path=/pet]]
+[[PROPERTY|correlationId=path_not_found]]
 [[PROPERTY|method=GET]]
+[[PROPERTY|path=/pet]]
 [[PROPERTY|statusCode=404]]
+correlationId=path_not_found
+method=GET
+path=/pet
+statusCode=404
             </system-out>
             <failure type="PathNotFound" message="error">Path not found</failure>
         </testcase>


### PR DESCRIPTION
## Problem
It would be nice if properties were also visible in the system-out so people can see them. It'd also be nice if you could see what a testcase was by glancing at the name.

## Solution
- Update the junit template to include properties in the system-out
- Update the testcase name to include method, path, and the correlation ID