### PR TITLE
Move props into failure tag as well

### DIFF
--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -40,12 +40,6 @@ Which should return a JUnit report that resembles the following:
 [[PROPERTY|path=/pets]]
 [[PROPERTY|responseContentType=application/json]]
 [[PROPERTY|statusCode=200]]
-correlationId=e73ac0a9-a28e-446c-aa21-aaad827a489d
-method=GET
-operationId=getPets
-path=/pets
-responseContentType=application/json
-statusCode=200
         </system-out>
     </testcase>
 </testsuites>

--- a/templates/junit.xml
+++ b/templates/junit.xml
@@ -2,10 +2,14 @@
     <testsuite name="openapi-validator-proxy" tests="{{testcases.len()}}" failures="{{failed_testcases}}">{% for case in testcases %}
         <testcase name="{{case.name}}" time="{{case.time}}">
             <system-out>{% for prop in case.properties %}
-[[PROPERTY|{{prop.name}}={{prop.value}}]]{% endfor %}{% for prop in case.properties %}
-{{prop.name}}={{prop.value}}{% endfor %}
+[[PROPERTY|{{prop.name}}={{prop.value}}]]{% endfor %}
             </system-out>{% for failure in case.failures %}
-            <failure type="{{failure.type}}" message="error">{{ failure.text|safe }}</failure>{% endfor %}
+            <failure type="{{failure.type}}" message="failure">{% for prop in case.properties %}
+[[PROPERTY|{{prop.name}}={{prop.value}}]]{% endfor %}
+
+Failure message:
+{{ failure.text|safe }}
+            </failure>{% endfor %}
         </testcase>{% endfor %}
     </testsuite>
 </testsuites>

--- a/tests/snapshots/integration__delete_with_204.snap
+++ b/tests/snapshots/integration__delete_with_204.snap
@@ -13,13 +13,6 @@ expression: xml
 [[PROPERTY|pathParameter-petId=1]]
 [[PROPERTY|responseContentType=]]
 [[PROPERTY|statusCode=204]]
-correlationId=delete_with_204
-method=DELETE
-operationId=deletePet
-path=/pets/1
-pathParameter-petId=1
-responseContentType=
-statusCode=204
             </system-out>
         </testcase>
     </testsuite>

--- a/tests/snapshots/integration__empty_body_200.snap
+++ b/tests/snapshots/integration__empty_body_200.snap
@@ -12,14 +12,18 @@ expression: xml
 [[PROPERTY|path=/pets/1]]
 [[PROPERTY|pathParameter-petId=1]]
 [[PROPERTY|statusCode=200]]
-correlationId=empty_body_200
-method=DELETE
-operationId=deletePet
-path=/pets/1
-pathParameter-petId=1
-statusCode=200
             </system-out>
-            <failure type="InvalidStatusCode" message="error">Response not found for status code</failure>
+            <failure type="InvalidStatusCode" message="failure">
+[[PROPERTY|correlationId=empty_body_200]]
+[[PROPERTY|method=DELETE]]
+[[PROPERTY|operationId=deletePet]]
+[[PROPERTY|path=/pets/1]]
+[[PROPERTY|pathParameter-petId=1]]
+[[PROPERTY|statusCode=200]]
+
+Failure message:
+Response not found for status code
+            </failure>
         </testcase>
     </testsuite>
 </testsuites>

--- a/tests/snapshots/integration__failed_json_deserialization.snap
+++ b/tests/snapshots/integration__failed_json_deserialization.snap
@@ -13,15 +13,19 @@ expression: xml
 [[PROPERTY|pathParameter-petId=1]]
 [[PROPERTY|responseContentType=application/json]]
 [[PROPERTY|statusCode=200]]
-correlationId=failed_json_deserialization
-method=GET
-operationId=showPetById
-path=/pets/1
-pathParameter-petId=1
-responseContentType=application/json
-statusCode=200
             </system-out>
-            <failure type="FailedJSONDeserialization" message="error">Failed to parse response body as JSON</failure>
+            <failure type="FailedJSONDeserialization" message="failure">
+[[PROPERTY|correlationId=failed_json_deserialization]]
+[[PROPERTY|method=GET]]
+[[PROPERTY|operationId=showPetById]]
+[[PROPERTY|path=/pets/1]]
+[[PROPERTY|pathParameter-petId=1]]
+[[PROPERTY|responseContentType=application/json]]
+[[PROPERTY|statusCode=200]]
+
+Failure message:
+Failed to parse response body as JSON
+            </failure>
         </testcase>
     </testsuite>
 </testsuites>

--- a/tests/snapshots/integration__failed_validation_unexpected_boolean.snap
+++ b/tests/snapshots/integration__failed_validation_unexpected_boolean.snap
@@ -13,15 +13,19 @@ expression: xml
 [[PROPERTY|pathParameter-petId=1]]
 [[PROPERTY|responseContentType=application/json]]
 [[PROPERTY|statusCode=200]]
-correlationId=failed_validation_unexpected_boolean
-method=GET
-operationId=showPetById
-path=/pets/1
-pathParameter-petId=1
-responseContentType=application/json
-statusCode=200
             </system-out>
-            <failure type="FailedValidation.UnexpectedBoolean" message="error">Received unexpected boolean at /id/</failure>
+            <failure type="FailedValidation.UnexpectedBoolean" message="failure">
+[[PROPERTY|correlationId=failed_validation_unexpected_boolean]]
+[[PROPERTY|method=GET]]
+[[PROPERTY|operationId=showPetById]]
+[[PROPERTY|path=/pets/1]]
+[[PROPERTY|pathParameter-petId=1]]
+[[PROPERTY|responseContentType=application/json]]
+[[PROPERTY|statusCode=200]]
+
+Failure message:
+Received unexpected boolean at /id/
+            </failure>
         </testcase>
     </testsuite>
 </testsuites>

--- a/tests/snapshots/integration__failed_validation_unexpected_null.snap
+++ b/tests/snapshots/integration__failed_validation_unexpected_null.snap
@@ -13,15 +13,19 @@ expression: xml
 [[PROPERTY|pathParameter-petId=1]]
 [[PROPERTY|responseContentType=application/json]]
 [[PROPERTY|statusCode=200]]
-correlationId=failed_validation_unexpected_null
-method=GET
-operationId=showPetById
-path=/pets/1
-pathParameter-petId=1
-responseContentType=application/json
-statusCode=200
             </system-out>
-            <failure type="FailedValidation.UnexpectedNull" message="error">Received null value when null is not allowed at /id/</failure>
+            <failure type="FailedValidation.UnexpectedNull" message="failure">
+[[PROPERTY|correlationId=failed_validation_unexpected_null]]
+[[PROPERTY|method=GET]]
+[[PROPERTY|operationId=showPetById]]
+[[PROPERTY|path=/pets/1]]
+[[PROPERTY|pathParameter-petId=1]]
+[[PROPERTY|responseContentType=application/json]]
+[[PROPERTY|statusCode=200]]
+
+Failure message:
+Received null value when null is not allowed at /id/
+            </failure>
         </testcase>
     </testsuite>
 </testsuites>

--- a/tests/snapshots/integration__failed_validation_unexpected_number.snap
+++ b/tests/snapshots/integration__failed_validation_unexpected_number.snap
@@ -13,15 +13,19 @@ expression: xml
 [[PROPERTY|pathParameter-petId=1]]
 [[PROPERTY|responseContentType=application/json]]
 [[PROPERTY|statusCode=200]]
-correlationId=failed_validation_unexpected_number
-method=GET
-operationId=showPetById
-path=/pets/1
-pathParameter-petId=1
-responseContentType=application/json
-statusCode=200
             </system-out>
-            <failure type="FailedValidation.UnexpectedNumber" message="error">Received unexpected number at /name/</failure>
+            <failure type="FailedValidation.UnexpectedNumber" message="failure">
+[[PROPERTY|correlationId=failed_validation_unexpected_number]]
+[[PROPERTY|method=GET]]
+[[PROPERTY|operationId=showPetById]]
+[[PROPERTY|path=/pets/1]]
+[[PROPERTY|pathParameter-petId=1]]
+[[PROPERTY|responseContentType=application/json]]
+[[PROPERTY|statusCode=200]]
+
+Failure message:
+Received unexpected number at /name/
+            </failure>
         </testcase>
     </testsuite>
 </testsuites>

--- a/tests/snapshots/integration__failed_validation_unexpected_property.snap
+++ b/tests/snapshots/integration__failed_validation_unexpected_property.snap
@@ -13,15 +13,19 @@ expression: xml
 [[PROPERTY|pathParameter-petId=1]]
 [[PROPERTY|responseContentType=application/json]]
 [[PROPERTY|statusCode=200]]
-correlationId=failed_validation_unexpected_property
-method=GET
-operationId=showPetById
-path=/pets/1
-pathParameter-petId=1
-responseContentType=application/json
-statusCode=200
             </system-out>
-            <failure type="FailedValidation.UnexpectedProperty" message="error">Unexpected property at /extra, value "field"</failure>
+            <failure type="FailedValidation.UnexpectedProperty" message="failure">
+[[PROPERTY|correlationId=failed_validation_unexpected_property]]
+[[PROPERTY|method=GET]]
+[[PROPERTY|operationId=showPetById]]
+[[PROPERTY|path=/pets/1]]
+[[PROPERTY|pathParameter-petId=1]]
+[[PROPERTY|responseContentType=application/json]]
+[[PROPERTY|statusCode=200]]
+
+Failure message:
+Unexpected property at /extra, value "field"
+            </failure>
         </testcase>
     </testsuite>
 </testsuites>

--- a/tests/snapshots/integration__failed_validation_unexpected_string.snap
+++ b/tests/snapshots/integration__failed_validation_unexpected_string.snap
@@ -13,15 +13,19 @@ expression: xml
 [[PROPERTY|pathParameter-petId=1]]
 [[PROPERTY|responseContentType=application/json]]
 [[PROPERTY|statusCode=200]]
-correlationId=failed_validation_unexpected_string
-method=GET
-operationId=showPetById
-path=/pets/1
-pathParameter-petId=1
-responseContentType=application/json
-statusCode=200
             </system-out>
-            <failure type="FailedValidation.UnexpectedString" message="error">Received unexpected string at /id/</failure>
+            <failure type="FailedValidation.UnexpectedString" message="failure">
+[[PROPERTY|correlationId=failed_validation_unexpected_string]]
+[[PROPERTY|method=GET]]
+[[PROPERTY|operationId=showPetById]]
+[[PROPERTY|path=/pets/1]]
+[[PROPERTY|pathParameter-petId=1]]
+[[PROPERTY|responseContentType=application/json]]
+[[PROPERTY|statusCode=200]]
+
+Failure message:
+Received unexpected string at /id/
+            </failure>
         </testcase>
     </testsuite>
 </testsuites>

--- a/tests/snapshots/integration__failed_validation_unsupported_schema_kind.snap
+++ b/tests/snapshots/integration__failed_validation_unsupported_schema_kind.snap
@@ -12,14 +12,18 @@ expression: xml
 [[PROPERTY|path=/any_of_pet_schema]]
 [[PROPERTY|responseContentType=application/json]]
 [[PROPERTY|statusCode=200]]
-correlationId=failed_validation_unsupported_schema_kind
-method=GET
-operationId=anyOfPetSchema
-path=/any_of_pet_schema
-responseContentType=application/json
-statusCode=200
             </system-out>
-            <failure type="FailedValidation.UnsupportedSchemaKind" message="error">Received unsupported schema kind: AnyOf { any_of: [Reference { reference: "#/components/schemas/Pet" }, Item(Schema { schema_data: SchemaData { nullable: false, read_only: false, write_only: false, deprecated: false, external_docs: None, example: None, title: None, description: None, discriminator: None, default: None, extensions: {} }, schema_kind: Type(Object(ObjectType { properties: {"id": Item(Schema { schema_data: SchemaData { nullable: false, read_only: false, write_only: false, deprecated: false, external_docs: None, example: None, title: None, description: None, discriminator: None, default: None, extensions: {} }, schema_kind: Type(Integer(IntegerType { format: Item(Int64), multiple_of: None, exclusive_minimum: false, exclusive_maximum: false, minimum: None, maximum: None, enumeration: [] })) }), "name": Item(Schema { schema_data: SchemaData { nullable: false, read_only: false, write_only: false, deprecated: false, external_docs: None, example: None, title: None, description: None, discriminator: None, default: None, extensions: {} }, schema_kind: Type(String(StringType { format: Empty, pattern: None, enumeration: [], min_length: None, max_length: None })) })}, required: ["id", "name"], additional_properties: None, min_properties: None, max_properties: None })) })] } at /</failure>
+            <failure type="FailedValidation.UnsupportedSchemaKind" message="failure">
+[[PROPERTY|correlationId=failed_validation_unsupported_schema_kind]]
+[[PROPERTY|method=GET]]
+[[PROPERTY|operationId=anyOfPetSchema]]
+[[PROPERTY|path=/any_of_pet_schema]]
+[[PROPERTY|responseContentType=application/json]]
+[[PROPERTY|statusCode=200]]
+
+Failure message:
+Received unsupported schema kind: AnyOf { any_of: [Reference { reference: "#/components/schemas/Pet" }, Item(Schema { schema_data: SchemaData { nullable: false, read_only: false, write_only: false, deprecated: false, external_docs: None, example: None, title: None, description: None, discriminator: None, default: None, extensions: {} }, schema_kind: Type(Object(ObjectType { properties: {"id": Item(Schema { schema_data: SchemaData { nullable: false, read_only: false, write_only: false, deprecated: false, external_docs: None, example: None, title: None, description: None, discriminator: None, default: None, extensions: {} }, schema_kind: Type(Integer(IntegerType { format: Item(Int64), multiple_of: None, exclusive_minimum: false, exclusive_maximum: false, minimum: None, maximum: None, enumeration: [] })) }), "name": Item(Schema { schema_data: SchemaData { nullable: false, read_only: false, write_only: false, deprecated: false, external_docs: None, example: None, title: None, description: None, discriminator: None, default: None, extensions: {} }, schema_kind: Type(String(StringType { format: Empty, pattern: None, enumeration: [], min_length: None, max_length: None })) })}, required: ["id", "name"], additional_properties: None, min_properties: None, max_properties: None })) })] } at /
+            </failure>
         </testcase>
     </testsuite>
 </testsuites>

--- a/tests/snapshots/integration__invalid_http_method.snap
+++ b/tests/snapshots/integration__invalid_http_method.snap
@@ -10,12 +10,16 @@ expression: xml
 [[PROPERTY|method=DELETE]]
 [[PROPERTY|path=/pets]]
 [[PROPERTY|statusCode=405]]
-correlationId=invalid_http_method
-method=DELETE
-path=/pets
-statusCode=405
             </system-out>
-            <failure type="InvalidHTTPMethod" message="error">Invalid HTTP method</failure>
+            <failure type="InvalidHTTPMethod" message="failure">
+[[PROPERTY|correlationId=invalid_http_method]]
+[[PROPERTY|method=DELETE]]
+[[PROPERTY|path=/pets]]
+[[PROPERTY|statusCode=405]]
+
+Failure message:
+Invalid HTTP method
+            </failure>
         </testcase>
     </testsuite>
 </testsuites>

--- a/tests/snapshots/integration__invalid_status_code.snap
+++ b/tests/snapshots/integration__invalid_status_code.snap
@@ -11,13 +11,17 @@ expression: xml
 [[PROPERTY|operationId=listPets]]
 [[PROPERTY|path=/pets]]
 [[PROPERTY|statusCode=600]]
-correlationId=invalid_status_code
-method=GET
-operationId=listPets
-path=/pets
-statusCode=600
             </system-out>
-            <failure type="InvalidStatusCode" message="error">Response not found for status code</failure>
+            <failure type="InvalidStatusCode" message="failure">
+[[PROPERTY|correlationId=invalid_status_code]]
+[[PROPERTY|method=GET]]
+[[PROPERTY|operationId=listPets]]
+[[PROPERTY|path=/pets]]
+[[PROPERTY|statusCode=600]]
+
+Failure message:
+Response not found for status code
+            </failure>
         </testcase>
     </testsuite>
 </testsuites>

--- a/tests/snapshots/integration__mismatch_non_empty_body.snap
+++ b/tests/snapshots/integration__mismatch_non_empty_body.snap
@@ -13,15 +13,19 @@ expression: xml
 [[PROPERTY|pathParameter-petId=1]]
 [[PROPERTY|responseContentType=]]
 [[PROPERTY|statusCode=202]]
-correlationId=mismatch_non_empty_body
-method=GET
-operationId=showPetById
-path=/pets/1
-pathParameter-petId=1
-responseContentType=
-statusCode=202
             </system-out>
-            <failure type="MismatchNonEmptyBody" message="error">Receieved response body when empty body is expected</failure>
+            <failure type="MismatchNonEmptyBody" message="failure">
+[[PROPERTY|correlationId=mismatch_non_empty_body]]
+[[PROPERTY|method=GET]]
+[[PROPERTY|operationId=showPetById]]
+[[PROPERTY|path=/pets/1]]
+[[PROPERTY|pathParameter-petId=1]]
+[[PROPERTY|responseContentType=]]
+[[PROPERTY|statusCode=202]]
+
+Failure message:
+Receieved response body when empty body is expected
+            </failure>
         </testcase>
     </testsuite>
 </testsuites>

--- a/tests/snapshots/integration__mismatched_content_type_header.snap
+++ b/tests/snapshots/integration__mismatched_content_type_header.snap
@@ -12,14 +12,18 @@ expression: xml
 [[PROPERTY|path=/pets]]
 [[PROPERTY|responseContentType=wrong]]
 [[PROPERTY|statusCode=200]]
-correlationId=mismatched_content_type_header
-method=GET
-operationId=listPets
-path=/pets
-responseContentType=wrong
-statusCode=200
             </system-out>
-            <failure type="MismatchedContentTypeHeader" message="error">Spec does not contain matching response for Content-Type: wrong</failure>
+            <failure type="MismatchedContentTypeHeader" message="failure">
+[[PROPERTY|correlationId=mismatched_content_type_header]]
+[[PROPERTY|method=GET]]
+[[PROPERTY|operationId=listPets]]
+[[PROPERTY|path=/pets]]
+[[PROPERTY|responseContentType=wrong]]
+[[PROPERTY|statusCode=200]]
+
+Failure message:
+Spec does not contain matching response for Content-Type: wrong
+            </failure>
         </testcase>
     </testsuite>
 </testsuites>

--- a/tests/snapshots/integration__missing_content_type_header.snap
+++ b/tests/snapshots/integration__missing_content_type_header.snap
@@ -11,13 +11,17 @@ expression: xml
 [[PROPERTY|operationId=listPets]]
 [[PROPERTY|path=/pets]]
 [[PROPERTY|statusCode=200]]
-correlationId=missing_content_type_header
-method=GET
-operationId=listPets
-path=/pets
-statusCode=200
             </system-out>
-            <failure type="MissingContentTypeHeader" message="error">Response did not include a Content-Type header</failure>
+            <failure type="MissingContentTypeHeader" message="failure">
+[[PROPERTY|correlationId=missing_content_type_header]]
+[[PROPERTY|method=GET]]
+[[PROPERTY|operationId=listPets]]
+[[PROPERTY|path=/pets]]
+[[PROPERTY|statusCode=200]]
+
+Failure message:
+Response did not include a Content-Type header
+            </failure>
         </testcase>
     </testsuite>
 </testsuites>

--- a/tests/snapshots/integration__missing_schema_definition.snap
+++ b/tests/snapshots/integration__missing_schema_definition.snap
@@ -12,14 +12,18 @@ expression: xml
 [[PROPERTY|path=/missing_pets_schema]]
 [[PROPERTY|responseContentType=application/json]]
 [[PROPERTY|statusCode=200]]
-correlationId=missing_schema_definition
-method=GET
-operationId=missingPetsSchema
-path=/missing_pets_schema
-responseContentType=application/json
-statusCode=200
             </system-out>
-            <failure type="MissingSchemaDefinition" message="error">Could not find schema defined inline or as a #/components/schemas/ reference</failure>
+            <failure type="MissingSchemaDefinition" message="failure">
+[[PROPERTY|correlationId=missing_schema_definition]]
+[[PROPERTY|method=GET]]
+[[PROPERTY|operationId=missingPetsSchema]]
+[[PROPERTY|path=/missing_pets_schema]]
+[[PROPERTY|responseContentType=application/json]]
+[[PROPERTY|statusCode=200]]
+
+Failure message:
+Could not find schema defined inline or as a #/components/schemas/ reference
+            </failure>
         </testcase>
     </testsuite>
 </testsuites>

--- a/tests/snapshots/integration__path_not_found.snap
+++ b/tests/snapshots/integration__path_not_found.snap
@@ -10,12 +10,16 @@ expression: xml
 [[PROPERTY|method=GET]]
 [[PROPERTY|path=/pet]]
 [[PROPERTY|statusCode=404]]
-correlationId=path_not_found
-method=GET
-path=/pet
-statusCode=404
             </system-out>
-            <failure type="PathNotFound" message="error">Path not found</failure>
+            <failure type="PathNotFound" message="failure">
+[[PROPERTY|correlationId=path_not_found]]
+[[PROPERTY|method=GET]]
+[[PROPERTY|path=/pet]]
+[[PROPERTY|statusCode=404]]
+
+Failure message:
+Path not found
+            </failure>
         </testcase>
     </testsuite>
 </testsuites>


### PR DESCRIPTION
## Problem
It seems like only the body of the failure message is included when displaying messages. This results in properties not being as visible as I would like them to be.

## Solution
Duplicate properties in the failure message body as well